### PR TITLE
Add CMake Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.20)
+
+set(MY_Project_Name Proxy-Server)
+
+project(${MY_Project_Name})
+
+file(GLOB HEADERS
+    ${CMAKE_SOURCE_DIR}/include/*.h
+)
+
+file(GLOB SOURCES
+    ${CMAKE_SOURCE_DIR}/src/*.c
+)
+
+find_package(CURL REQUIRED) 
+
+add_executable(Proxy-Server-CMake ${HEADERS} ${SOURCES})
+
+target_link_libraries(Proxy-Server-CMake CURL::libcurl)


### PR DESCRIPTION
This pull request adds CMake support to the project.

Following are the steps to build the project using cmake.
1) make sure curl is installed. (run `sudo apt install libcurl4-openssl-dev` for debian based machines)
2) from the root of the project run `cmake -B build-cmake -S .`
3) once the `build-cmake` folder has been generated, run `cmake --build build-cmake`
4) you can see the generated execution file named "Proxy-Server-CMake"